### PR TITLE
Add ability to specify the scroll container node.

### DIFF
--- a/src/hooks/useVirtualGrid.js
+++ b/src/hooks/useVirtualGrid.js
@@ -5,7 +5,7 @@ import useVirtualGridChildren from './useVirtualGridChildren'
 const useVirtualGrid = ({ cell, total, viewportRowOffset = 4, onRender, scrollContainer }) => {
   const rowOffset = Math.max(2, Math.round(viewportRowOffset / 2) * 2)
   const { display, style, ref } = useVirtualGridDisplay({ cell, total, rowOffset })
-  const { firstRowIndex, scrolling } = useVirtualGridFirstRowIndex({ ...display, scrollContainer })
+  const { firstRowIndex, scrolling } = useVirtualGridFirstRowIndex(display, scrollContainer)
   const children = useVirtualGridChildren({ firstRowIndex, scrolling, display, onRender })
 
   return { container: { ref, style }, children }

--- a/src/hooks/useVirtualGrid.js
+++ b/src/hooks/useVirtualGrid.js
@@ -2,10 +2,10 @@ import useVirtualGridDisplay from './useVirtualGridDisplay'
 import useVirtualGridFirstRowIndex from './useVirtualGridFirstRowIndex'
 import useVirtualGridChildren from './useVirtualGridChildren'
 
-const useVirtualGrid = ({ cell, total, viewportRowOffset = 4, onRender }) => {
+const useVirtualGrid = ({ cell, total, viewportRowOffset = 4, onRender, scrollContainer }) => {
   const rowOffset = Math.max(2, Math.round(viewportRowOffset / 2) * 2)
   const { display, style, ref } = useVirtualGridDisplay({ cell, total, rowOffset })
-  const { firstRowIndex, scrolling } = useVirtualGridFirstRowIndex(display)
+  const { firstRowIndex, scrolling } = useVirtualGridFirstRowIndex({ ...display, scrollContainer })
   const children = useVirtualGridChildren({ firstRowIndex, scrolling, display, onRender })
 
   return { container: { ref, style }, children }

--- a/src/hooks/useVirtualGridFirstRowIndex.js
+++ b/src/hooks/useVirtualGridFirstRowIndex.js
@@ -1,13 +1,22 @@
 import { useMemo, useEffect, useState, useRef } from 'react'
 import nanobounce from 'nanobounce'
 
-const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset }) => {
+const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset, scrollContainer }) => {
   const isClient = typeof window === 'object'
   const computeFirstRowIndex = useRef()
   const debounce = useMemo(() => nanobounce(200), [])
 
+  // Utilize the container that was passed in if so.
+  const container = scrollContainer ?? window;
+
   computeFirstRowIndex.current = () => {
-    const position = isClient ? Math.max(0, window.scrollY - layout.top) : 0
+
+    // window and divs use a different property for scroll
+    // position. Determine what we can get.
+    let scrollTop = window.scrollY;
+    if (container.scrollTop) scrollTop = container.scrollTop; 
+
+    const position = isClient ? Math.max(0, scrollTop - layout.top) : 0
     const firstVisibleRowIndex = Math.floor(position / cell.height)
     const firstRowIndex = Math.max(0, firstVisibleRowIndex - rowOffset / 2)
     return firstRowIndex
@@ -27,8 +36,8 @@ const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset }) => {
       debounce(() => setScrolling(false))
     }
 
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
+    container.addEventListener('scroll', handleScroll)
+    return () => container.removeEventListener('scroll', handleScroll)
   }, [])
 
   return { firstRowIndex, scrolling }

--- a/src/hooks/useVirtualGridFirstRowIndex.js
+++ b/src/hooks/useVirtualGridFirstRowIndex.js
@@ -13,8 +13,7 @@ const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset, scrollContainer 
 
     // window and divs use a different property for scroll
     // position. Determine what we can get.
-    let scrollTop = window.scrollY;
-    if (container.scrollTop) scrollTop = container.scrollTop; 
+    const scrollTop = container === window ? container.scrollY : container.scrollTop
 
     const position = isClient ? Math.max(0, scrollTop - layout.top) : 0
     const firstVisibleRowIndex = Math.floor(position / cell.height)

--- a/src/hooks/useVirtualGridFirstRowIndex.js
+++ b/src/hooks/useVirtualGridFirstRowIndex.js
@@ -1,7 +1,7 @@
 import { useMemo, useEffect, useState, useRef } from 'react'
 import nanobounce from 'nanobounce'
 
-const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset, scrollContainer }) => {
+const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset }, scrollContainer) => {
   const isClient = typeof window === 'object'
   const computeFirstRowIndex = useRef()
   const debounce = useMemo(() => nanobounce(200), [])

--- a/src/hooks/useVirtualGridFirstRowIndex.js
+++ b/src/hooks/useVirtualGridFirstRowIndex.js
@@ -7,7 +7,7 @@ const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset, scrollContainer 
   const debounce = useMemo(() => nanobounce(200), [])
 
   // Utilize the container that was passed in if so.
-  const container = scrollContainer ?? window;
+  const container = scrollContainer ?? window
 
   computeFirstRowIndex.current = () => {
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ import useVirtualGrid from './hooks/useVirtualGrid'
 
 export const VirtualGrid = ({ child: Child, childProps = {}, useChildProps = null, ...props }) => {
   const { container, children } = useVirtualGrid(props)
-
+  
   return (
     <div {...container}>
       {children.map(({ key, ...props }) => (
@@ -30,6 +30,7 @@ VirtualGrid.propTypes = {
   child: PropTypes.elementType.isRequired,
   childProps: PropTypes.object,
   useChildProps: PropTypes.func,
+  scrollContainer: PropTypes.node
 }
 
 export default memo(VirtualGrid)


### PR DESCRIPTION
I ran into an issue in my application where my scroll container is not the window. I made this change so I can pass in the node of my scroll container to get things working. Seems like something that may be useful to others that may come across your project.