### PR TITLE
Add scroll container as useEffect dependecy to avoid loss of sync between container and scroll event.

### DIFF
--- a/src/hooks/useVirtualGridFirstRowIndex.js
+++ b/src/hooks/useVirtualGridFirstRowIndex.js
@@ -36,7 +36,7 @@ const useVirtualGridFirstRowIndex = ({ layout, cell, rowOffset }, scrollContaine
 
     container.addEventListener('scroll', handleScroll)
     return () => container.removeEventListener('scroll', handleScroll)
-  }, [])
+  }, [container])
 
   return { firstRowIndex, scrolling }
 }


### PR DESCRIPTION
I found this issue using the component in a new project. It seems when I added the scroll container logic previously the element was in the layout and not prone to re-rendering. In my new project this seems not to be the case so adding the container to the dependency array seems to fix it.